### PR TITLE
Fix incorrect string representation of DateTimes in ImGuiFileView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# JetBrains Rider
+.idea/

--- a/Hexa.NET.ImGui.Widgets/Dialogs/ImGuiFileView.cs
+++ b/Hexa.NET.ImGui.Widgets/Dialogs/ImGuiFileView.cs
@@ -120,7 +120,7 @@
 
                 if (ImGui.TableSetColumnIndex(1))
                 {
-                    ImGui.TextDisabled($"{entry.DateModified:dd/mm/yyyy HH:mm}");
+                    ImGui.TextDisabled($"{entry.DateModified:dd/MM/yyyy HH:mm}");
                 }
 
                 if (ImGui.TableSetColumnIndex(2))
@@ -292,7 +292,7 @@
 
                 if (ImGui.TableSetColumnIndex(1))
                 {
-                    Utf8Formatter.Format(entry.DateModified, stack, 64, "dd/mm/yyyy HH:mm");
+                    Utf8Formatter.Format(entry.DateModified, stack, 64, "dd/MM/yyyy HH:mm");
                     ImGui.TextDisabled(stack);
                 }
 
@@ -457,7 +457,7 @@
 
                 if (ImGui.TableSetColumnIndex(1))
                 {
-                    ImGui.TextDisabled($"{entry.DateModified:dd/mm/yyyy HH:mm}");
+                    ImGui.TextDisabled($"{entry.DateModified:dd/MM/yyyy HH:mm}");
                 }
 
                 if (ImGui.TableSetColumnIndex(2))


### PR DESCRIPTION
Just a small visual bug I noticed when working with file dialogs:

![image](https://github.com/user-attachments/assets/01a063a1-8842-4b0d-897e-010399c39d69)