### PR TITLE
FIX: Added missing import in performance tests package

### DIFF
--- a/PerformanceTests/Program.cs
+++ b/PerformanceTests/Program.cs
@@ -2,6 +2,7 @@
 using BenchmarkDotNet.Running;
 using Hexa.NET.ImGui.Widgets.Text;
 using System.Text;
+using Hexa.NET.Utilities.Text;
 
 public class Program
 {


### PR DESCRIPTION
Utf8Formatter in the performance tests package wasn't imported correctly, causing a build error and nasty red lines.

Very simple pull request; I mostly just fixed it because red lines in my IDE bothers me.